### PR TITLE
Fix Target VMAF svt-av1 crf range error

### DIFF
--- a/ff-utils-winforms/UI/Tasks/Av1anUi.cs
+++ b/ff-utils-winforms/UI/Tasks/Av1anUi.cs
@@ -233,7 +233,7 @@ namespace Nmkoder.UI.Tasks
         public static Dictionary<string, string> GetVideoArgsFromUi()
         {
             Dictionary<string, string> dict = new Dictionary<string, string>();
-            dict.Add("qMode", form.encQualModeBox.SelectedIndex.ToString());
+            dict.Add("qMode", form.av1anQualModeBox.SelectedIndex.ToString());
             dict.Add("q", form.av1anQualityUpDown.Value.ToString());
             dict.Add("preset", form.av1anPresetBox.Text.ToLower());
             dict.Add("pixFmt", PixFmtUtils.GetFormat(CodecUtils.GetCodec((CodecUtils.Av1anCodec)Program.mainForm.av1anCodecBox.SelectedIndex).ColorFormats[Program.mainForm.av1anColorsBox.SelectedIndex]).Name);


### PR DESCRIPTION
If I understand it right `encQualModeBox.SelectedIndex` should be about the UI of the QuickConvert tab not Av1An.
So I modified it, and now finally the encoding with svt-av1 also updated, works.
https://github.com/n00mkrad/nmkoder/issues/36
